### PR TITLE
Bail out if the message transformer has an invalid `this` value

### DIFF
--- a/broadcast.js
+++ b/broadcast.js
@@ -13,6 +13,8 @@ exports.server = function server(primus) {
   primus.transform('incoming', function incoming(packet) {
     var data = packet.data;
 
+    if (!(this instanceof Spark)) return;
+
     if (
          'object' !== typeof data     // Events are objects.
       || !Array.isArray(data.emit)    // Not an emit object.

--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ exports.client = function client(primus) {
     var data = packet.data;
 
     if (
-         'object' !== typeof data                       // Events are objects.
+         this !== primus                                // Incorrect context.
+      || 'object' !== typeof data                       // Events are objects.
       || !~toString.call(data.emit).indexOf(' Array]')  // Not an emit object.
     ) {
       return;
@@ -56,7 +57,8 @@ exports.server = function server(primus) {
     var data = packet.data;
 
     if (
-         'object' !== typeof data     // Events are objects.
+         !(this instanceof Spark)     // Incorrect context.
+      || 'object' !== typeof data     // Events are objects.
       || !Array.isArray(data.emit)    // Not an emit object.
     ) {
       return;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "assume": "1.3.x",
     "mocha": "2.3.x",
     "pre-commit": "1.1.x",
-    "primus": "3.2.x",
+    "primus": "4.0.x",
     "ws": "0.8.x"
   }
 }


### PR DESCRIPTION
It is possible that the incoming message transformer gets called with an unexpected `this` value. An example is when using `primus-emit` in conjunction with `substream`. When this happens an error is thrown as described in #4.

This should fix the issue.

Closes #4.